### PR TITLE
Improve DiagnosticSensor Discovery robustness

### DIFF
--- a/Its.Log/DiagnosticSensor.cs
+++ b/Its.Log/DiagnosticSensor.cs
@@ -192,31 +192,6 @@ namespace Its.Log.Instrumentation
                 });
         }
 
-        internal static AggregateCatalog AggregateSafely(IEnumerable<AssemblyCatalog> catalogs)
-        {
-            var catalog = new AggregateCatalog();
-
-            foreach (var assemblyCatalog in catalogs)
-            {
-                try
-                {
-                    // trigger possible exceptions due to missing assemblies. if these are going to cause a problem, let them do so on a code path that actually uses them directly, because otherwise it can be very hard to figure out the source of the problem.
-                    var parts = assemblyCatalog.Parts;
-                    catalog.Catalogs.Add(assemblyCatalog);
-                }
-                catch (ReflectionTypeLoadException ex)
-                {
-                    ex.RaiseErrorEvent();
-                }
-                catch (FileNotFoundException ex)
-                {
-                    ex.RaiseErrorEvent();
-                }
-            }
-
-            return catalog;
-        }
-
         /// <summary>
         /// Gets the name of a sensor.
         /// </summary>

--- a/Its.Log/DiagnosticSensor.cs
+++ b/Its.Log/DiagnosticSensor.cs
@@ -153,41 +153,43 @@ namespace Its.Log.Instrumentation
         /// </summary>
         public static ConcurrentDictionary<string, DiagnosticSensor> Discover()
         {
-            // find all exported sensor functions across loaded assemblies
-            var assemblies = AppDomain.CurrentDomain.GetAssemblies()
-                                      .Where(a => !a.IsDynamic)
-                                      .Where(a => !a.GlobalAssemblyCache);
-            var discoveredSensors = new ConcurrentDictionary<string, DiagnosticSensor>();
-
-            using (var catalog = AggregateSafely(assemblies.Select(a => new AssemblyCatalog(a))))
-            using (var container = new CompositionContainer(catalog))
-            {
-                try
+            return AppDomain.CurrentDomain
+                .GetAssemblies()
+                .Where(a => !a.IsDynamic && !a.GlobalAssemblyCache)
+                .SelectMany(a =>
                 {
-                    var sensors = container.GetExports<object>("DiagnosticSensor")
-                                           .Select(lazy => lazy.Value)
-                                           .OfType<ExportedDelegate>()
-                                           .Select(sensorMethod => new DiagnosticSensor(sensorMethod))
-                                           .OrderBy(sensor => sensor.Name)
-                                           .ThenBy(sensor => sensor.DeclaringType.Assembly.FullName)
-                                           .ToArray();
-
-                    // FIX: (Discover) we should be graceful about collisions or deterministic about ordering
-                    foreach (var sensor in sensors)
+                    try
                     {
-                        discoveredSensors[sensor.Name] = sensor;
+                        return new CompositionContainer(new AggregateCatalog(new AssemblyCatalog(a)))
+                            .GetExports<object>("DiagnosticSensor")
+                            .Select(lazy => lazy.Value)
+                            .OfType<ExportedDelegate>()
+                            .Select(sensorMethod => new DiagnosticSensor(sensorMethod));
                     }
-                }
-                catch (ReflectionTypeLoadException ex)
+                    catch (Exception ex)
+                    {
+                        if (ex is TypeLoadException || ex is ReflectionTypeLoadException || ex is FileNotFoundException ||
+                            ex is FileLoadException)
+                        {
+                            return new[]
+                            {
+                                new DiagnosticSensor(typeof (Exception),
+                                    "AssemblyLoadError-" + a.FullName,
+                                    typeof (DiagnosticSensor),
+                                    new Func<Exception>(() => ex))
+                            };
+                        }
+                        throw;
+                    }
+                })
+                .OrderBy(sensor => sensor.Name)
+                .ThenBy(sensor => sensor.DeclaringType.Assembly.FullName)
+                .Aggregate(new ConcurrentDictionary<string, DiagnosticSensor>(), (sensors, sensor) =>
                 {
-                    discoveredSensors["SensorDiscoveryError"] = new DiagnosticSensor(typeof (Exception),
-                                                                                     "SensorDiscoveryError",
-                                                                                     typeof (DiagnosticSensor),
-                                                                                     new Func<Exception>(() => ex));
-                }
-
-                return discoveredSensors;
-            }
+                    // FIX: (Discover) we should be graceful about collisions or deterministic about ordering
+                    sensors[sensor.Name] = sensor;
+                    return sensors;
+                });
         }
 
         internal static AggregateCatalog AggregateSafely(IEnumerable<AssemblyCatalog> catalogs)

--- a/Its.Log/Its.Log.nuspec
+++ b/Its.Log/Its.Log.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>Its.Log</id>
-    <version>2.8.2</version>
+    <version>2.8.3</version>
     <authors>jonsequitur,Microsoft</authors>
     <title>Its.Log</title>
     <owners>Microsoft,jonsequitur</owners>


### PR DESCRIPTION
Improve DiagnosticSensor Discovery to load assemblies individually and handle more exceptions, including during GetExports(). I was seeing `TypeLoadException` thrown to [security issues of assemblies](http://anthonyfassett.blogspot.com/2013/11/updating-razor-20-to-30-with-aspnet-mvc.html), and since IIS can just add junk to your AppDomain, this needs to be handled better.