### PR TITLE
Replace the JsonFormatter with a default formatter for the Monitoring…

### DIFF
--- a/Its.Log.Monitoring/DefaultJsonFormatterAttribute.cs
+++ b/Its.Log.Monitoring/DefaultJsonFormatterAttribute.cs
@@ -14,8 +14,10 @@ namespace Its.Log.Monitoring
             HttpControllerSettings controllerSettings,
             HttpControllerDescriptor controllerDescriptor)
         {
-            controllerSettings.Formatters.Remove(controllerSettings.Formatters.JsonFormatter);
-            controllerSettings.Formatters.Add(new JsonMediaTypeFormatter());
+            if (controllerSettings.Formatters.JsonFormatter != null)
+            {
+                controllerSettings.Formatters[controllerSettings.Formatters.IndexOf(controllerSettings.Formatters.JsonFormatter)] = new JsonMediaTypeFormatter();
+            }
         }
     }
 }

--- a/Its.Log.Monitoring/DefaultJsonFormatterAttribute.cs
+++ b/Its.Log.Monitoring/DefaultJsonFormatterAttribute.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft. All rights reserved. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Net.Http.Formatting;
+using System.Web.Http.Controllers;
+using Its.Recipes;
+
+namespace Its.Log.Monitoring
+{
+    internal sealed class DefaultJsonFormatterAttribute : Attribute, IControllerConfiguration
+    {
+        public void Initialize(
+            HttpControllerSettings controllerSettings,
+            HttpControllerDescriptor controllerDescriptor)
+        {
+            controllerSettings.Formatters.Remove(controllerSettings.Formatters.JsonFormatter);
+            controllerSettings.Formatters.Add(new JsonMediaTypeFormatter());
+        }
+    }
+}

--- a/Its.Log.Monitoring/Its.Log.Monitoring.csproj
+++ b/Its.Log.Monitoring/Its.Log.Monitoring.csproj
@@ -90,6 +90,7 @@
     <Compile Include="TagConstraint.cs" />
     <Compile Include="CacheExtensions.cs" />
     <Compile Include="EnvironmentConstraint.cs" />
+    <Compile Include="DefaultJsonFormatterAttribute.cs" />
     <Compile Include="TestUiHtmlConfigurationAttribute.cs" />
     <Compile Include="TestUiScriptFormatter.cs" />
     <Compile Include="HttpConfigurationExtensions.cs" />

--- a/Its.Log.Monitoring/MonitoringTestController.cs
+++ b/Its.Log.Monitoring/MonitoringTestController.cs
@@ -10,6 +10,7 @@ using System.Web.Http.Routing;
 namespace Its.Log.Monitoring
 {
     [TestUiHtmlConfiguration]
+    [DefaultJsonFormatter]
     public class MonitoringTestController : ApiController
     {
         [HttpGet]


### PR DESCRIPTION
Replace the JsonFormatter with a default formatter for the Monitoring Controller (by way of a DefaultJsonFormatter attribute)

Fix for #11 