### PR TITLE
confirmation timings

### DIFF
--- a/Its.Log.Lite.UnitTests/Its.Log.Lite.UnitTests.csproj
+++ b/Its.Log.Lite.UnitTests/Its.Log.Lite.UnitTests.csproj
@@ -37,8 +37,12 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="FluentAssertions">
-      <HintPath>..\packages\FluentAssertions.2.1.0.0\lib\net45\FluentAssertions.dll</HintPath>
+    <Reference Include="FluentAssertions, Version=4.0.0.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\FluentAssertions.4.0.0\lib\net45\FluentAssertions.dll</HintPath>
+    </Reference>
+    <Reference Include="FluentAssertions.Core">
+      <HintPath>..\packages\FluentAssertions.4.0.0\lib\net45\FluentAssertions.Core.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="nunit.framework">

--- a/Its.Log.Lite.UnitTests/packages.config
+++ b/Its.Log.Lite.UnitTests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FluentAssertions" version="2.1.0.0" targetFramework="net45" />
+  <package id="FluentAssertions" version="4.0.0" targetFramework="net45" />
   <package id="NUnit" version="2.6.2" targetFramework="net45" />
   <package id="Rx-Core" version="2.1.30214.0" targetFramework="net45" />
   <package id="Rx-Interfaces" version="2.1.30214.0" targetFramework="net45" />

--- a/Its.Log.Monitoring.UnitTests/Its.Log.Monitoring.UnitTests.csproj
+++ b/Its.Log.Monitoring.UnitTests/Its.Log.Monitoring.UnitTests.csproj
@@ -38,8 +38,13 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="FluentAssertions">
-      <HintPath>..\packages\FluentAssertions.2.1.0.0\lib\net45\FluentAssertions.dll</HintPath>
+    <Reference Include="FluentAssertions, Version=4.0.0.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\FluentAssertions.4.0.0\lib\net45\FluentAssertions.dll</HintPath>
+    </Reference>
+    <Reference Include="FluentAssertions.Core">
+      <HintPath>..\packages\FluentAssertions.4.0.0\lib\net45\FluentAssertions.Core.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">

--- a/Its.Log.Monitoring.UnitTests/packages.config
+++ b/Its.Log.Monitoring.UnitTests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FluentAssertions" version="2.1.0.0" targetFramework="net45" />
+  <package id="FluentAssertions" version="4.0.0" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi" version="5.2.3" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net45" />

--- a/Its.Log.UnitTests/Its.Log.UnitTests.csproj
+++ b/Its.Log.UnitTests/Its.Log.UnitTests.csproj
@@ -60,9 +60,12 @@
     <Reference Include="AssemblyWithMissingDependency">
       <HintPath>Resources\AssemblyWithMissingDependency.dll</HintPath>
     </Reference>
-    <Reference Include="FluentAssertions, Version=2.1.0.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
+    <Reference Include="FluentAssertions, Version=4.0.0.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\FluentAssertions.2.1.0.0\lib\net40\FluentAssertions.dll</HintPath>
+      <HintPath>..\packages\FluentAssertions.4.0.0\lib\net45\FluentAssertions.dll</HintPath>
+    </Reference>
+    <Reference Include="FluentAssertions.Core">
+      <HintPath>..\packages\FluentAssertions.4.0.0\lib\net45\FluentAssertions.Core.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Moq">

--- a/Its.Log.UnitTests/packages.config
+++ b/Its.Log.UnitTests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FluentAssertions" version="2.1.0.0" targetFramework="net40" />
+  <package id="FluentAssertions" version="4.0.0" targetFramework="net45" />
   <package id="Ix_Experimental-Main" version="1.1.10823" targetFramework="net40" />
   <package id="Moq" version="4.0.10827" targetFramework="net40" />
   <package id="Newtonsoft.Json" version="5.0.6" targetFramework="net40" />

--- a/Recipes.Tests/Recipes.Tests.csproj
+++ b/Recipes.Tests/Recipes.Tests.csproj
@@ -37,11 +37,13 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="FluentAssertions">
-      <HintPath>..\packages\FluentAssertions.3.5.0\lib\net45\FluentAssertions.dll</HintPath>
+    <Reference Include="FluentAssertions, Version=4.0.0.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\FluentAssertions.4.0.0\lib\net45\FluentAssertions.dll</HintPath>
     </Reference>
-    <Reference Include="FluentAssertions.Core">
-      <HintPath>..\packages\FluentAssertions.3.5.0\lib\net45\FluentAssertions.Core.dll</HintPath>
+    <Reference Include="FluentAssertions.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\FluentAssertions.4.0.0\lib\net45\FluentAssertions.Core.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json">
       <HintPath>..\packages\Newtonsoft.Json.6.0.4\lib\net45\Newtonsoft.Json.dll</HintPath>

--- a/Recipes.Tests/packages.config
+++ b/Recipes.Tests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FluentAssertions" version="3.5.0" targetFramework="net45" />
+  <package id="FluentAssertions" version="4.0.0" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi" version="5.2.3" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net45" />


### PR DESCRIPTION
This adds timings in milliseconds for `LogActivity.Confirm` checkpoints, so the output looks like this:

```
Confirmed = { Starting (@0ms), Still going... (@123ms), Done! (@1071ms) }
```