### PR TITLE
Telemetry based assertions for Monitoring

### DIFF
--- a/Its.Log.Monitoring.UnitTests/AssertionTests.cs
+++ b/Its.Log.Monitoring.UnitTests/AssertionTests.cs
@@ -1,0 +1,180 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Its.Log.Monitoring.UnitTests
+{
+    [TestFixture]
+    public class AssertionTests
+    {
+        private readonly Aggregation<IEnumerable<int>, long> five = Enumerable.Range(1, 5).CountOf(_ => true);
+        private readonly IEnumerable<Result> results = Enumerable.Range(1, 10).Select(i => new Result(i%2 == 0));
+
+        public class Result
+        {
+            public Result(bool success)
+            {
+                Success = success;
+            }
+
+            public bool Success { get; }
+        }
+
+        [Test]
+        public void BeEqualTo_does_not_throw_when_the_expected_value_is_equal_to_the_actual()
+        {
+            Action assert = () => five.Should().BeEqualTo(5);
+            assert.ShouldNotThrow();
+        }
+
+        [Test]
+        public void BeEqualTo_throws_when_the_expected_value_is_greater_than_the_actual()
+        {
+            Action assert = () => five.Should().BeEqualTo(4);
+            assert.ShouldThrow<AggregationAssertionException<IEnumerable<int>>>();
+        }
+
+        [Test]
+        public void BeEqualTo_throws_when_the_expected_value_is_less_than_the_actual()
+        {
+            Action assert = () => five.Should().BeEqualTo(6);
+            assert.ShouldThrow<AggregationAssertionException<IEnumerable<int>>>();
+        }
+
+        [Test]
+        public void BeGreaterThan_does_not_throw_when_the_expected_value_is_greater_than_the_actual()
+        {
+            Action assert = () => five.Should().BeGreaterThan(4);
+            assert.ShouldNotThrow();
+        }
+
+        [Test]
+        public void BeGreaterThan_throws_when_the_expected_value_is_equal_to_the_actual()
+        {
+            Action assert = () => five.Should().BeGreaterThan(5);
+            assert.ShouldThrow<AggregationAssertionException<IEnumerable<int>>>();
+        }
+
+        [Test]
+        public void BeGreaterThan_throws_when_the_expected_value_is_less_than_the_actual()
+        {
+            Action assert = () => five.Should().BeGreaterThan(6);
+            assert.ShouldThrow<AggregationAssertionException<IEnumerable<int>>>();
+        }
+
+        [Test]
+        public void BeGreaterThanOrEqualTo_does_not_throw_when_the_expected_value_is_equal_to_the_actual()
+        {
+            Action assert = () => five.Should().BeGreaterThanOrEqualTo(5);
+            assert.ShouldNotThrow();
+        }
+
+        [Test]
+        public void BeGreaterThanOrEqualTo_does_not_throw_when_the_expected_value_is_greater_than_the_actual()
+        {
+            Action assert = () => five.Should().BeGreaterThanOrEqualTo(4);
+            assert.ShouldNotThrow();
+        }
+
+        [Test]
+        public void BeGreaterThanOrEqualTo_throws_when_the_expected_value_is_less_than_the_actual()
+        {
+            Action assert = () => five.Should().BeGreaterThanOrEqualTo(6);
+            assert.ShouldThrow<AggregationAssertionException<IEnumerable<int>>>();
+        }
+
+        [Test]
+        public void BeLessThan_does_not_throw_when_the_expected_value_is_less_than_the_actual()
+        {
+            Action assert = () => five.Should().BeLessThan(6);
+            assert.ShouldNotThrow();
+        }
+
+        [Test]
+        public void BeLessThan_throws_when_the_expected_value_is_equal_to_the_actual()
+        {
+            Action assert = () => five.Should().BeLessThan(5);
+            assert.ShouldThrow<AggregationAssertionException<IEnumerable<int>>>();
+        }
+
+        [Test]
+        public void BeLessThan_throws_when_the_expected_value_is_greater_than_the_actual()
+        {
+            Action assert = () => five.Should().BeLessThan(4);
+            assert.ShouldThrow<AggregationAssertionException<IEnumerable<int>>>();
+        }
+
+        [Test]
+        public void BeLessThanOrEqualTo_does_not_throw_when_the_expected_value_is_equal_to_the_actual()
+        {
+            Action assert = () => five.Should().BeLessThanOrEqualTo(5);
+            assert.ShouldNotThrow();
+        }
+
+        [Test]
+        public void BeLessThanOrEqualTo_does_not_throw_when_the_expected_value_is_less_than_the_actual()
+        {
+            Action assert = () => five.Should().BeLessThanOrEqualTo(6);
+            assert.ShouldNotThrow();
+        }
+
+        [Test]
+        public void BeLessThanOrEqualTo_throws_when_the_expected_value_is_greater_than_the_actual()
+        {
+            Action assert = () => five.Should().BeLessThanOrEqualTo(4);
+            assert.ShouldThrow<AggregationAssertionException<IEnumerable<int>>>();
+        }
+
+        [Test]
+        public void CountOf_is_callable_on_an_empty_enumerable()
+        {
+            Enumerable.Empty<Result>().CountOf(r => true).Result.Should().Be(0);
+        }
+
+        [Test]
+        public void CountOf_returns_the_expected_amount()
+        {
+            results.CountOf(r => r.Success).Result.Should().Be(5);
+        }
+
+        [Test]
+        public void CountOf_returns_the_expected_amount_when_the_amount_of_matches_is_0()
+        {
+            results.CountOf(r => false).Result.Should().Be(0);
+        }
+
+        [Test]
+        public void CountOf_returns_the_values_of_the_enumerable_that_met_the_condition()
+        {
+            results.CountOf(r => r.Success).State.ShouldBeEquivalentTo(results.Where(r => r.Success));
+        }
+
+        [Test]
+        public void PercentageOf_is_callable_on_an_empty_enumerable()
+        {
+            Enumerable.Empty<Result>().PercentageOf(r => true).Result.Should().Be(0.Percent());
+        }
+
+        [Test]
+        public void PercentageOf_returns_the_expected_percentage()
+        {
+            results.PercentageOf(r => r.Success).Result.Should().Be(50.Percent());
+        }
+
+        [Test]
+        public void PercentageOf_returns_the_values_of_the_enumerable_that_met_the_condition()
+        {
+            results.PercentageOf(r => r.Success).State.ShouldBeEquivalentTo(results.Where(r => r.Success));
+        }
+
+        [Test]
+        public void AggregationAssertionException_contains_TState()
+        {
+            Action assert = () => five.Should().BeLessThan(4);
+            assert.ShouldThrow<AggregationAssertionException<IEnumerable<int>>>()
+                  .And.State.ShouldBeEquivalentTo(Enumerable.Range(1, 5));
+        }
+    }
+}

--- a/Its.Log.Monitoring.UnitTests/Its.Log.Monitoring.UnitTests.csproj
+++ b/Its.Log.Monitoring.UnitTests/Its.Log.Monitoring.UnitTests.csproj
@@ -106,6 +106,7 @@
     <Compile Include="%28Its.Recipes%29\MaybeExtensions.cs" />
     <Compile Include="%28Its.Recipes%29\TestInputGenerator.cs" />
     <Compile Include="AssertionExtensionsTests.cs" />
+    <Compile Include="AssertionTests.cs" />
     <Compile Include="FakeHttpClient.cs" />
     <Compile Include="JsonContent.cs" />
     <Compile Include="JsonSerializationExtensions.cs" />
@@ -120,6 +121,7 @@
     <Compile Include="SensorRoutingTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="TargetBasedTestConstraintTests.cs" />
+    <Compile Include="TelemetryMonitorTests.cs" />
     <Compile Include="TestApi.cs" />
     <Compile Include="TestSensor.cs" />
   </ItemGroup>

--- a/Its.Log.Monitoring.UnitTests/MonitoringTestDiscoveryTests.cs
+++ b/Its.Log.Monitoring.UnitTests/MonitoringTestDiscoveryTests.cs
@@ -8,6 +8,7 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using System.Web.Http;
 using FluentAssertions;
+using Its.Log.Instrumentation.Extensions;
 using Its.Recipes;
 using NUnit.Framework;
 using Newtonsoft.Json.Linq;
@@ -445,6 +446,56 @@ namespace Its.Log.Monitoring.UnitTests
         private dynamic also_not_a_test()
         {
             return null;
+        }
+
+        public void no_more_than_10_percent_of_calls_have_failed()
+        {
+            Telemetry[] telemetry =
+            {
+                new Telemetry
+                {
+                    ElapsedMilliseconds = Any.Int(),
+                    OperationName = Any.CamelCaseName(),
+                    Succeeded = false,
+                    UserIdentifier = Any.Email(),
+                    Properties = {{"StatusCode", "500"}}
+                },
+                new Telemetry
+                {
+                    ElapsedMilliseconds = Any.Int(),
+                    OperationName = Any.CamelCaseName(),
+                    Succeeded = true,
+                    UserIdentifier = Any.Email(),
+                    Properties = {{"StatusCode", "200"}}
+                }
+            };
+
+            telemetry.PercentageOf(t => !t.Succeeded).Should().BeLessThanOrEqualTo(10.Percent());
+        }
+
+        public void telemetry_without_failures()
+        {
+            Telemetry[] telemetry =
+            {
+                new Telemetry
+                {
+                    ElapsedMilliseconds = Any.Int(),
+                    OperationName = Any.CamelCaseName(),
+                    Succeeded = true,
+                    UserIdentifier = Any.Email(),
+                    Properties = {{"StatusCode", "200"}}
+                },
+                new Telemetry
+                {
+                    ElapsedMilliseconds = Any.Int(),
+                    OperationName = Any.CamelCaseName(),
+                    Succeeded = true,
+                    UserIdentifier = Any.Email(),
+                    Properties = {{"StatusCode", "200"}}
+                }
+            };
+
+            telemetry.PercentageOf(t => t.Succeeded).Should().BeEqualTo(100.Percent());
         }
     }
 

--- a/Its.Log.Monitoring.UnitTests/TelemetryMonitorTests.cs
+++ b/Its.Log.Monitoring.UnitTests/TelemetryMonitorTests.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using FluentAssertions;
+using Newtonsoft.Json;
+using NUnit.Framework;
+
+namespace Its.Log.Monitoring.UnitTests
+{
+    [TestFixture]
+    public class TelemetryMonitorTests
+    {
+        private static HttpClient apiClient;
+
+        public TelemetryMonitorTests()
+        {
+            apiClient = new TestApi(targets => targets.Add("staging", "widgetapi", new Uri("http://staging.widgets.com")));
+        }
+
+        [Test]
+        public void a_request_to_a_telemetry_api_with_a_failed_result_should_contain_the_correct_message()
+        {
+            var response = apiClient.GetAsync("http://blammo.com/tests/staging/widgetapi/no_more_than_10_percent_of_calls_have_failed").Result;
+            var result = JsonConvert.DeserializeObject<dynamic>(response.Content.ReadAsStringAsync().Result);
+
+            ((string)result.Message).Should().Be("Expected a value less than or equal to 10% , but found 50%.");
+        }
+
+        [Test]
+        public void a_request_to_a_telemetry_api_with_a_failed_result_should_contain_the_related_telemetry_events()
+        {
+            var response = apiClient.GetAsync("http://blammo.com/tests/staging/widgetapi/no_more_than_10_percent_of_calls_have_failed").Result;
+            var result = JsonConvert.DeserializeObject<dynamic>(response.Content.ReadAsStringAsync().Result);
+
+            ((bool)result.RelatedEvents[0].Succeeded).Should().Be(false);
+        }
+
+        [Test]
+        public void a_request_to_a_telemetry_api_with_a_failed_result_should_contain_the_exception()
+        {
+            var response = apiClient.GetAsync("http://blammo.com/tests/staging/widgetapi/no_more_than_10_percent_of_calls_have_failed").Result;
+            var result = JsonConvert.DeserializeObject<dynamic>(response.Content.ReadAsStringAsync().Result);
+
+            ((string)result.Exception).Should().Contain("AggregationAssertionException");
+        }
+
+        [Test]
+        public void a_request_to_a_telemetry_api_with_failed_telemetry_results_should_return_InternalServerError()
+        {
+            var response = apiClient.GetAsync("http://blammo.com/tests/staging/widgetapi/no_more_than_10_percent_of_calls_have_failed").Result;
+            response.ShouldFailWith(HttpStatusCode.InternalServerError);
+        }
+
+        [Test]
+        public void a_request_to_a_telemetry_api_without_failed_telemetry_results_should_return_OK()
+        {
+            var response = apiClient.GetAsync("http://blammo.com/tests/staging/widgetapi/telemetry_without_failures").Result;
+            response.ShouldFailWith(HttpStatusCode.OK);
+        }
+    }
+}

--- a/Its.Log.Monitoring/Aggregation.cs
+++ b/Its.Log.Monitoring/Aggregation.cs
@@ -1,0 +1,14 @@
+namespace Its.Log.Monitoring
+{
+    public class Aggregation<TState, TResult>
+    {
+        public Aggregation(TState state, TResult result)
+        {
+            State = state;
+            Result = result;
+        }
+
+        public TResult Result { get; }
+        public TState State { get; }
+    }
+}

--- a/Its.Log.Monitoring/AggregationAssertionException.cs
+++ b/Its.Log.Monitoring/AggregationAssertionException.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace Its.Log.Monitoring
+{
+    public class AggregationAssertionException<TState> : Exception
+    {
+        public AggregationAssertionException(string message, TState state)
+            : base(message)
+        {
+            State = state;
+        }
+
+        public TState State { get; private set; }
+    }
+}

--- a/Its.Log.Monitoring/AggregationAssertions.cs
+++ b/Its.Log.Monitoring/AggregationAssertions.cs
@@ -1,0 +1,70 @@
+using System;
+
+namespace Its.Log.Monitoring
+{
+    public class AggregationAssertions<TState, TResult> where TResult : IComparable<TResult>
+    {
+        private readonly Aggregation<TState, TResult> Subject;
+
+        public AggregationAssertions(Aggregation<TState, TResult> aggregation)
+        {
+            if (aggregation == null)
+            {
+                throw new ArgumentNullException(nameof(aggregation));
+            }
+            Subject = aggregation;
+        }
+
+        public AggregationAssertions<TState, TResult> BeLessThan(TResult expected, string because = "")
+        {
+            var compareTo = Subject.Result.CompareTo(expected);
+            if (compareTo < 0)
+            {
+                return this;
+            }
+
+            throw new AggregationAssertionException<TState>($"Expected a value less than {expected} {because}, " +
+                                                            $"but found {Subject.Result}.", Subject.State);
+        }
+
+        public AggregationAssertions<TState, TResult> BeLessThanOrEqualTo(TResult expected, string because = "")
+        {
+            if (Subject.Result.CompareTo(expected) <= 0)
+            {
+                return this;
+            }
+            throw new AggregationAssertionException<TState>($"Expected a value less than or equal to {expected} {because}, " +
+                                                            $"but found {Subject.Result}.", Subject.State);
+        }
+
+        public AggregationAssertions<TState, TResult> BeGreaterThan(TResult expected, string because = "")
+        {
+            if (Subject.Result.CompareTo(expected) > 0)
+            {
+                return this;
+            }
+            throw new AggregationAssertionException<TState>($"Expected a value greater than {expected} {because}, " +
+                                                            $"but found {Subject.Result}.", Subject.State);
+        }
+
+        public AggregationAssertions<TState, TResult> BeGreaterThanOrEqualTo(TResult expected, string because = "")
+        {
+            if (Subject.Result.CompareTo(expected) >= 0)
+            {
+                return this;
+            }
+            throw new AggregationAssertionException<TState>($"Expected a value greater than or equal to {expected} {because}, " +
+                                                            $"but found {Subject.Result}.", Subject.State);
+        }
+
+        public AggregationAssertions<TState, TResult> BeEqualTo(TResult expected, string because = "")
+        {
+            if (Subject.Result.CompareTo(expected) == 0)
+            {
+                return this;
+            }
+            throw new AggregationAssertionException<TState>($"Expected a value equal to {expected} {because}, " +
+                                                            $"but found {Subject.Result}.", Subject.State);
+        }
+    }
+}

--- a/Its.Log.Monitoring/Its.Log.Monitoring.csproj
+++ b/Its.Log.Monitoring/Its.Log.Monitoring.csproj
@@ -87,10 +87,15 @@
     <Compile Include="AssertionFailedException.cs" />
     <Compile Include="AuthorizeSensorsAttribute.cs" />
     <Compile Include="Enumerable.cs" />
+    <Compile Include="Percentage.cs" />
+    <Compile Include="Aggregation.cs" />
+    <Compile Include="AggregationAssertionException.cs" />
+    <Compile Include="AggregationAssertions.cs" />
     <Compile Include="TagConstraint.cs" />
     <Compile Include="CacheExtensions.cs" />
     <Compile Include="EnvironmentConstraint.cs" />
     <Compile Include="DefaultJsonFormatterAttribute.cs" />
+    <Compile Include="Telemetry.cs" />
     <Compile Include="TestUiHtmlConfigurationAttribute.cs" />
     <Compile Include="TestUiScriptFormatter.cs" />
     <Compile Include="HttpConfigurationExtensions.cs" />

--- a/Its.Log.Monitoring/Percentage.cs
+++ b/Its.Log.Monitoring/Percentage.cs
@@ -1,0 +1,24 @@
+using System;
+
+namespace Its.Log.Monitoring
+{
+    public class Percentage : IComparable<Percentage>
+    {
+        private int value;
+
+        public Percentage(int value)
+        {
+            this.value = value;
+        }
+
+        public override string ToString()
+        {
+            return string.Format("{0}%", value);
+        }
+
+        public int CompareTo(Percentage other)
+        {
+            return value.CompareTo(other.value);
+        }
+    }
+}

--- a/Its.Log.Monitoring/Telemetry.cs
+++ b/Its.Log.Monitoring/Telemetry.cs
@@ -1,0 +1,45 @@
+//using System.Collections.Generic;
+//using Its.Log.Instrumentation;
+
+//namespace Its.Log.Monitoring
+//{
+//    public class Telemetry
+//    {
+//        private IDictionary<string, object> properties;
+
+//        /// <summary>
+//        ///     Gets or sets a value indicating whether an operation succeeded.
+//        /// </summary>
+//        /// <value>
+//        ///     <c>true</c> if the operation succeeded; otherwise, <c>false</c>.
+//        /// </value>
+//        public bool Succeeded { get; set; }
+
+//        /// <summary>
+//        ///     Gets or sets the name of the source operation.
+//        /// </summary>
+//        public string OperationName { get; set; }
+
+//        /// <summary>
+//        ///     Gets or sets the number of milliseconds that the operation took.
+//        /// </summary>
+//        public int ElapsedMilliseconds { get; set; }
+
+//        /// <summary>
+//        ///     Gets or sets the user identifier. The user identifier is intended to uniquely represent a user in the context of an
+//        ///     event.
+//        /// </summary>
+//        public string UserIdentifier { get; set; }
+
+//        /// <summary>
+//        ///     A dictionary that can be used to associated additional properties with a telemetry event.
+//        /// </summary>
+//        /// <value>
+//        ///     The properties.
+//        /// </value>
+//        public IDictionary<string, object> Properties
+//        {
+//            get { return properties ?? (properties = new Dictionary<string, object>()); }
+//        }
+//    }
+//}


### PR DESCRIPTION
Many monitors that i have seen get written return a pass or fail at the right times, however when they fail they usually dont have the pertinent results in the response. this is a change to make it easy to both assert on telemetry results but to also make the exceptions thrown and parsed by Monitoring more meaningful. 