### PR TITLE
bump itsLog version to fix type load error

### DIFF
--- a/Its.Log.Monitoring/Its.Log.Monitoring.nuspec
+++ b/Its.Log.Monitoring/Its.Log.Monitoring.nuspec
@@ -4,7 +4,7 @@
     <id>Its.Log.Monitoring</id>
     <authors>jonsequitur</authors>
     <title>Its.Log.Monitoring</title>
-    <version>1.9.0-beta</version>
+    <version>1.9.1-beta</version>
     <owners>Microsoft,jonsequitur</owners>
     <projectUrl>https://github.com/jonsequitur/its.log</projectUrl>
     <licenseUrl>http://opensource.org/licenses/MIT</licenseUrl>
@@ -12,7 +12,7 @@
     <description>Expose monitoring tests and sensors via HTTP for health monitoring, testing in production, integration testing, functionality testing, and smoke testing.</description>
     <tags>logging telemetry monitoring sensors diagnostics TiP testing</tags>
     <dependencies>
-      <dependency id="Its.Log" version="[2.8.0-beta,3.0.0)" />
+      <dependency id="Its.Log" version="[2.9.14,3.0.0)" />
       <dependency id="Microsoft.AspNet.WebApi" version="[5.1.2,)" />
     </dependencies>
   </metadata>

--- a/Its.Log/Its.Log.nuspec
+++ b/Its.Log/Its.Log.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>Its.Log</id>
-    <version>2.9.13</version>
+    <version>2.9.14</version>
     <authors>jonsequitur,Microsoft</authors>
     <title>Its.Log</title>
     <owners>Microsoft,jonsequitur</owners>

--- a/Its.Log/Properties/AssemblyInfo.cs
+++ b/Its.Log/Properties/AssemblyInfo.cs
@@ -12,8 +12,8 @@ using System.Runtime.InteropServices;
 
 
 [assembly: AssemblyVersion("2.7.0.0")]
-[assembly: AssemblyFileVersion("2.9.13")]
-[assembly: AssemblyInformationalVersion("2.9.13")]
+[assembly: AssemblyFileVersion("2.9.14")]
+[assembly: AssemblyInformationalVersion("2.9.14")]
 
 [assembly: AssemblyTrademark("Microsoft and Windows are registered trademarks of Microsoft Corporation.")]
 [assembly: AssemblyDelaySign(false)]

--- a/Recipes/WebApiTelemetry.nuspec
+++ b/Recipes/WebApiTelemetry.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>Its.Log.WebApiTelemetry</id>
     <title>Its.Log.WebApiTelemetry Recipe</title>
-    <version>1.0.5-beta</version>
+    <version>1.0.6-beta</version>
     <authors>jonsequitur</authors>
     <owners>Microsoft,jonsequitur</owners>
     <projectUrl>https://github.com/jonsequitur/its.log</projectUrl>

--- a/Recipes/WebApiTelemetry.nuspec
+++ b/Recipes/WebApiTelemetry.nuspec
@@ -13,7 +13,7 @@
     <tags>telemetry monitoring diagnostics Its.Log TiP</tags>
     <developmentDependency>true</developmentDependency>
     <dependencies>
-      <dependency id="Its.Log" version="[2.9.13,)" />
+      <dependency id="Its.Log" version="[2.9.14,)" />
       <dependency id="Microsoft.AspNet.WebApi" version="[5.1.2,)" />
     </dependencies>
     <frameworkAssemblies>


### PR DESCRIPTION
due to the removal of a friend assembly in its.log the following exception was thrown from assemblies that depend on it:
Could not load type 'Its.Recipes.MaybeExtensions' from assembly 'Its.Log, Version=2.7.0.0, Culture=neutral, PublicKeyToken=null'.