### PR TITLE
Configure ui script dependencies

### DIFF
--- a/Its.Log.Monitoring.UnitTests/MonitoringTestHtmlTests.cs
+++ b/Its.Log.Monitoring.UnitTests/MonitoringTestHtmlTests.cs
@@ -20,7 +20,7 @@ namespace Its.Log.Monitoring.UnitTests
         [Test]
         public void When_HTML_is_requested_then_the_tests_endpoint_returns_UI_bootstrap_HTML()
         {
-            var response = ReqestTestsHtml();
+            var response = RequestTestsHtml();
 
             var result = response.Content.ReadAsStringAsync().Result;
 
@@ -30,7 +30,7 @@ namespace Its.Log.Monitoring.UnitTests
         [Test]
         public void When_HTML_is_requested_then_it_contains_a_semantically_versioned_script_link()
         {
-            var response = ReqestTestsHtml();
+            var response = RequestTestsHtml();
 
             var result = response.Content.ReadAsStringAsync().Result;
 
@@ -40,20 +40,31 @@ namespace Its.Log.Monitoring.UnitTests
         [Test]
         public void The_script_location_for_the_UI_can_be_configured()
         {
-            var response = ReqestTestsHtml("//itscdn.azurewebsites.net/monitoring/1.0.0/monitoring.js");
+            var response = RequestTestsHtml("//itscdn.azurewebsites.net/monitoring/1.0.0/monitoring.js");
 
             var result = response.Content.ReadAsStringAsync().Result;
 
             result.Should().Contain(@"<script src=""//itscdn.azurewebsites.net/monitoring/1.0.0/monitoring.js?monitoringVersion=");
         }
 
-        private static HttpResponseMessage ReqestTestsHtml(string testUiScript = null)
+        [Test]
+        public void The_library_script_locations_for_the_UI_can_be_configured()
+        {
+            var response = RequestTestsHtml(testUiLibraryUrls: new []{ "/jquery.js", "/knockout.js" });
+
+            var result = response.Content.ReadAsStringAsync().Result;
+
+            result.Should().Contain(@"<script src=""/jquery.js""></script>");
+            result.Should().Contain(@"<script src=""/knockout.js""></script>");
+        }
+
+        private static HttpResponseMessage RequestTestsHtml(string testUiScript = null, string [] testUiLibraryUrls = null)
         {
             configuration = new HttpConfiguration();
             var constraintResolver = new DefaultInlineConstraintResolver();
             constraintResolver.ConstraintMap.Add("among", typeof(AmongConstraint));
             configuration.MapHttpAttributeRoutes(constraintResolver);
-            configuration.MapTestRoutes(testUiScriptUrl: testUiScript);
+            configuration.MapTestRoutes(testUiScriptUrl: testUiScript, testUiLibraryUrls: testUiLibraryUrls);
             configuration.EnsureInitialized();
 
             var server = new HttpServer(configuration);

--- a/Its.Log.Monitoring/TestUiHtmlConfigurationAttribute.cs
+++ b/Its.Log.Monitoring/TestUiHtmlConfigurationAttribute.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
 using System.Web.Http.Controllers;
 using Its.Recipes;
 
@@ -19,6 +20,12 @@ namespace Its.Log.Monitoring
                                             .IfContains("Its.Log.Monitoring.TestUiUri")
                                             .And()
                                             .IfTypeIs<string>()
-                                            .Else(() => "http://itsmonitoringux.azurewebsites.net/its.log.monitoring.js")));
+                                            .Else(() => "http://itsmonitoringux.azurewebsites.net/its.log.monitoring.js"),
+                        controllerDescriptor.Configuration
+                                            .Properties
+                                            .IfContains("Its.Log.Monitoring.TestLibraryUris")
+                                            .And()
+                                            .IfTypeIs<IEnumerable<string>>()
+                                            .Else(() => new string [] {})));
     }
 }

--- a/Its.Log.Monitoring/TestUiScriptFormatter.cs
+++ b/Its.Log.Monitoring/TestUiScriptFormatter.cs
@@ -2,8 +2,10 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Formatting;
@@ -16,15 +18,17 @@ namespace Its.Log.Monitoring
     {
         private readonly string bootstrapHtml;
 
-        public TestUiScriptFormatter(string scriptUrl)
+        public TestUiScriptFormatter(string scriptUrl, IEnumerable<string> libraryUrls)
         {
             var version = FileVersionInfo.GetVersionInfo(typeof (TestUiScriptFormatter).Assembly.Location).FileVersion;
+            var libraryScriptRefs = string.Join("\n", libraryUrls.Select(u => $@"<script src=""{u}""></script>"));
 
             bootstrapHtml =
                 $@"<!doctype html>
 <html lang=""en"">
     <head>
 	    <meta charset=""UTF-8"">
+        {libraryScriptRefs}
 	    <script src=""{scriptUrl}?monitoringVersion={version}""></script>
     </head>
     <body>


### PR DESCRIPTION
Allow callers of MapTestRoutes to supply a list of scripts to be loaded before the main UI script.