### PR TITLE
Confirmation timings in json

### DIFF
--- a/Its.Log.UnitTests/JsonSerializationTests.cs
+++ b/Its.Log.UnitTests/JsonSerializationTests.cs
@@ -7,8 +7,6 @@ using System.Diagnostics;
 using System.IO;
 using FluentAssertions;
 using System.Linq;
-using System.Threading.Tasks;
-using FluentAssertions;
 using Its.Log.Instrumentation.Extensions;
 using Its.Recipes;
 using Newtonsoft.Json;
@@ -106,6 +104,22 @@ namespace Its.Log.Instrumentation.UnitTests
 
             Assert.That(new FileInfo(@"c:\temp\1.log").ToLogString(),
                         Is.EqualTo("{\"$type\":\"System.IO.FileInfo, mscorlib\",\"OriginalPath\":\"c:\\\\temp\\\\1.log\",\"FullPath\":\"c:\\\\temp\\\\1.log\"}"));
+        }
+
+        [Test]
+        public void Confirmation_timings_appear_in_JSON()
+        {
+            var log = new List<LogEntry>();
+
+            using (Log.Events().Subscribe(log.Add))
+            using (var activity = Log.Enter(() => { }))
+            {
+                activity.Confirm(() => "hello");
+            }
+
+            var json = JsonConvert.SerializeObject(log.Last());
+
+            json.Should().Match("*hello (@*ms)*");
         }
 
         [Ignore("Perf test")]

--- a/Its.Log/Its.Log.nuspec
+++ b/Its.Log/Its.Log.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>Its.Log</id>
-    <version>2.9.13</version>
+    <version>2.9.14</version>
     <authors>jonsequitur,Microsoft</authors>
     <title>Its.Log</title>
     <owners>Microsoft,jonsequitur</owners>

--- a/Its.Log/LogActivity.cs
+++ b/Its.Log/LogActivity.cs
@@ -227,8 +227,10 @@ namespace Its.Log.Instrumentation
 
             internal object ResolvedValue => value ?? (value = Accessor.InvokeSafely());
 
+            public string Value => ToString();
+
             public override string ToString() =>
-                (elapsedMilliseconds == null)
+                elapsedMilliseconds == null
                     ? ResolvedValue.ToLogString()
                     : $"{ResolvedValue.ToLogString()} (@{elapsedMilliseconds}ms)";
 

--- a/Its.Log/Properties/AssemblyInfo.cs
+++ b/Its.Log/Properties/AssemblyInfo.cs
@@ -12,8 +12,7 @@ using System.Runtime.InteropServices;
 
 
 [assembly: AssemblyVersion("2.7.0.0")]
-[assembly: AssemblyFileVersion("2.9.13")]
-[assembly: AssemblyInformationalVersion("2.9.13")]
+[assembly: AssemblyInformationalVersion("2.9.14")]
 
 [assembly: AssemblyTrademark("Microsoft and Windows are registered trademarks of Microsoft Corporation.")]
 [assembly: AssemblyDelaySign(false)]

--- a/Recipes/WebApiTelemetry.nuspec
+++ b/Recipes/WebApiTelemetry.nuspec
@@ -13,7 +13,7 @@
     <tags>telemetry monitoring diagnostics Its.Log TiP</tags>
     <developmentDependency>true</developmentDependency>
     <dependencies>
-      <dependency id="Its.Log" version="[2.9.13,)" />
+      <dependency id="Its.Log" version="[2.9.14,)" />
       <dependency id="Microsoft.AspNet.WebApi" version="[5.1.2,)" />
     </dependencies>
     <frameworkAssemblies>


### PR DESCRIPTION
When JSON serializing a LogActivity, confirmations was showing up empty. This adds a Value property that the serializer can write out.